### PR TITLE
ci: migrate npm publish to Trusted Publishers (OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,31 +8,32 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     environment: NPM
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Enable Corepack
         run: corepack enable
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 23.4.0
           cache: "yarn"
+          registry-url: "https://registry.npmjs.org"
 
       - run: yarn
 
-      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
+      - name: Update npm to Trusted-Publisher-capable version
+        run: npm install -g npm@latest
 
-      # Standard release (no beta or rc)
       - name: Publish standard release
         if: "!(contains(github.event.release.tag_name, 'beta') || contains(github.event.release.tag_name, 'rc'))"
-        run: yarn publish
+        run: npm publish --provenance
 
-      # Pre-release (betaX or rcX)
       - name: Publish pre-release (beta/rc)
         if: "contains(github.event.release.tag_name, 'beta') || contains(github.event.release.tag_name, 'rc')"
-        run: yarn publish --tag next
+        run: npm publish --provenance --tag next


### PR DESCRIPTION
## Summary

- Remove `NPM_AUTOMATION_TOKEN`-based `~/.npmrc` write; authenticate to npm via OIDC Trusted Publishers instead
- Add `id-token: write` and `contents: read` permissions to the publish job
- Bump `actions/checkout` and `actions/setup-node` to `v6`
- Add `registry-url: https://registry.npmjs.org` to `setup-node` so OIDC targets the right registry
- Install latest `npm` globally so the runner has a Trusted-Publisher-capable version
- Switch publish command from `yarn publish` to `npm publish --provenance` (Yarn Classic cannot generate provenance attestations); pre-releases use `npm publish --provenance --tag next`
- Yarn is still used for install

## Required setup before merge

- Configure the Trusted Publisher entry on npmjs.com for `@prototyp/skeleform` (package settings → Trusted Publisher):
  - Organization: `prototypdigital`
  - Repository: `skeleform`
  - Workflow filename: `npm-publish.yml`
  - Environment: `NPM`
- Keep the `NPM_AUTOMATION_TOKEN` secret in place until the first successful OIDC publish, then revoke it on npmjs.com and remove the secret from the repo/environment

## Test plan

- [ ] Dry-run by cutting a prerelease tag (e.g. `vX.Y.Z-rc.1`) and confirming the workflow publishes successfully via OIDC with no token
- [ ] Verify the provenance badge appears on the npmjs.com package page for the published version
- [ ] Revoke the old `NPM_AUTOMATION_TOKEN` on npmjs.com and remove the GitHub secret